### PR TITLE
Avoid locking tables during mysql dump

### DIFF
--- a/BACKUP
+++ b/BACKUP
@@ -2,4 +2,4 @@
 URL=${PWD##*/}
 db_container_name=`echo ${URL}_db_1 | sed "s/\.//g" | sed "s/-//g"`; \
 
-docker exec $db_container_name bash -c 'mysqldump --all-databases --events -uroot -p$MYSQL_ROOT_PASSWORD' > ./mysql/dump.sql
+docker exec $db_container_name bash -c 'mysqldump --skip-lock-tables --single-transaction --all-databases --events -uroot -p$MYSQL_ROOT_PASSWORD' | gzip -9 >  ./mysql/piwik_$(date +%Y%d%mT%H%M).sql.gz

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Once it is done, you can connect to the port of the host by adding this line to 
 ```
 web:
 ...
-  - ports:
+  ports:
     - "443:443"
     - "80:80"
 ...


### PR DESCRIPTION
Implemented the change that @Toub brought up in issue #2 as we needed backups for our deployments, Also added gzip compression to the backup job. 
Thanks 👍  
