### PR TITLE
explicitly select docker:fpm image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     networks:
     - back
   app:
-    image: piwik
+    image: piwik:fpm
     links:
       - db
     volumes:
@@ -35,7 +35,7 @@ services:
     - back
     - lb_web
   cron:
-    image: piwik
+    image: piwik:fpm
     links:
       - db
     volumes_from:


### PR DESCRIPTION
docker-piwik now defaults to apache instead of fpm which doesn't work
with this nginx config so select fpm explicitly.

this breaks running setups on `docker-compose pull`